### PR TITLE
Some extra security with HTTPS

### DIFF
--- a/Hangouts/ViewController.swift
+++ b/Hangouts/ViewController.swift
@@ -23,7 +23,7 @@ class ViewController: NSViewController {
 
         // Do any additional setup after loading the view.
         
-        let url : String = "http://hangouts.google.com"
+        let url : String = "https://hangouts.google.com"
         self.webView.mainFrame.loadRequest(NSURLRequest(URL: NSURL(string: url)!))
 
     }


### PR DESCRIPTION
It might be forced redirect by hangouts itself, but why have a roundtrip for that? Also, what if it doesn't?
